### PR TITLE
Visual Editor now saves in UTF-8 without BOM

### DIFF
--- a/Tools/StartVisualEditor.ps1
+++ b/Tools/StartVisualEditor.ps1
@@ -190,9 +190,10 @@ try {
                     continue
                 }
 
-                # Save to file
-                Set-Content -Path $dataFilePath -Value $body -Encoding UTF8 -NoNewline
-                Write-Host "  Data saved successfully" -ForegroundColor Green
+                # Save to file (UTF-8 without BOM)
+                $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+                [System.IO.File]::WriteAllText($dataFilePath, $body, $utf8NoBom)
+                Write-Host "  Data saved successfully (UTF-8 without BOM)" -ForegroundColor Green
 
                 $successMsg = @{ success = $true; message = "Data saved successfully" } | ConvertTo-Json
                 $buffer = [System.Text.Encoding]::UTF8.GetBytes($successMsg)


### PR DESCRIPTION
## Description
Fixed saving so it will use only UTF-8 without BOM

## Deployment Notes

After this PR is merged to `main`:
- ✅ Changes will automatically sync to Azure DevOps `dev` branch
- ✅ Dev environment will be built and deployed automatically
- ⚠️ **IMPORTANT**: Validate changes at https://dev-swgoh-stackrank-westus.azurewebsites.net/stackrank before production promotion
- ℹ️ A comment will be posted on this PR with the deployment status and DEV URL
