### PR TITLE
Remove Capt Rex's omicron synergy with Cody and Clone Sergeant.

### DIFF
--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -5101,7 +5101,8 @@
             }
           ]
         }
-      ]
+      ],
+      "requiresAllZetas": false
     },
     {
       "id": "KUIIL",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -1587,7 +1587,6 @@
       "id": "CC2224",
       "baseTier": 14,
       "requiresAllZetas": false,
-      "requiredZetas": [],
       "synergySets": [
         {
           "synergyEnhancement": 4,
@@ -1609,10 +1608,14 @@
           "categoryDefinitions": [
             {
               "include": [
-                "Clone Trooper"
+                "Clone Trooper",
+                "Light Side"
               ],
               "numberMatchesRequired": 3
             }
+          ],
+          "skipIfPresentCharacters": [
+            "GENERALSKYWALKER"
           ]
         }
       ]
@@ -1796,10 +1799,14 @@
           "categoryDefinitions": [
             {
               "include": [
-                "Clone Trooper"
+                "Clone Trooper",
+                "Light Side"
               ],
               "numberMatchesRequired": 3
             }
+          ],
+          "skipIfPresentCharacters": [
+            "GENERALSKYWALKER"
           ]
         }
       ]

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -2151,7 +2151,12 @@
     {
       "baseTier": 4,
       "id": "DARTHBANE",
-      "omicronEnhancement": 1
+      "omicronEnhancement": 1,
+      "requiredZetas": [
+        "uniqueskill_DARTHBANE01",
+        "basicskill_DARTHBANE"
+      ],
+      "requiresAllZetas": false
     },
     {
       "id": "DARTHMALAK",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -2151,12 +2151,7 @@
     {
       "baseTier": 4,
       "id": "DARTHBANE",
-      "omicronEnhancement": 1,
-      "requiredZetas": [
-        "uniqueskill_DARTHBANE01",
-        "basicskill_DARTHBANE"
-      ],
-      "requiresAllZetas": false
+      "omicronEnhancement": 1
     },
     {
       "id": "DARTHMALAK",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -1362,7 +1362,6 @@
       "synergySets": [
         {
           "synergyEnhancement": 3,
-          "synergyEnhancementOmicron": 2,
           "characters": [
             "CLONESERGEANTPHASEI",
             "CC2224"


### PR DESCRIPTION
## Description
These three characters are almost never used together so they should not
get a two tier boost.

### Characters Affected
- Cody
- Clone Sergeant

### Changes Made
- Removes the 2 tier improvement to Cody and Clone Sergeant when Capt Rex has his omicron.