### PR TITLE
Remove Capt Phasma's synergy with SLKR.

### DIFF
--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -5101,7 +5101,8 @@
             }
           ]
         }
-      ]
+      ],
+      "requiresAllZetas": false
     },
     {
       "id": "KUIIL",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -1587,7 +1587,6 @@
       "id": "CC2224",
       "baseTier": 14,
       "requiresAllZetas": false,
-      "requiredZetas": [],
       "synergySets": [
         {
           "synergyEnhancement": 4,
@@ -1609,10 +1608,14 @@
           "categoryDefinitions": [
             {
               "include": [
-                "Clone Trooper"
+                "Clone Trooper",
+                "Light Side"
               ],
               "numberMatchesRequired": 3
             }
+          ],
+          "skipIfPresentCharacters": [
+            "GENERALSKYWALKER"
           ]
         }
       ]
@@ -1796,10 +1799,14 @@
           "categoryDefinitions": [
             {
               "include": [
-                "Clone Trooper"
+                "Clone Trooper",
+                "Light Side"
               ],
               "numberMatchesRequired": 3
             }
+          ],
+          "skipIfPresentCharacters": [
+            "GENERALSKYWALKER"
           ]
         }
       ]

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -2151,7 +2151,12 @@
     {
       "baseTier": 4,
       "id": "DARTHBANE",
-      "omicronEnhancement": 1
+      "omicronEnhancement": 1,
+      "requiredZetas": [
+        "uniqueskill_DARTHBANE01",
+        "basicskill_DARTHBANE"
+      ],
+      "requiresAllZetas": false
     },
     {
       "id": "DARTHMALAK",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -2151,12 +2151,7 @@
     {
       "baseTier": 4,
       "id": "DARTHBANE",
-      "omicronEnhancement": 1,
-      "requiredZetas": [
-        "uniqueskill_DARTHBANE01",
-        "basicskill_DARTHBANE"
-      ],
-      "requiresAllZetas": false
+      "omicronEnhancement": 1
     },
     {
       "id": "DARTHMALAK",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -6427,14 +6427,7 @@
       "id": "PHASMA",
       "baseTier": 14,
       "requiresAllZetas": false,
-      "requiredZetas": [],
       "synergySets": [
-        {
-          "synergyEnhancement": 5,
-          "characters": [
-            "SUPREMELEADERKYLOREN"
-          ]
-        },
         {
           "synergyEnhancement": 3,
           "characters": [


### PR DESCRIPTION
## Description
Capt. Phasma is rarely used with SLKR in the current meta so the extra
tiers over the synergy with other first order toons is unnecessary.

### Characters Affected
- Capt Phasma