### PR TITLE
Disable Bastila Shan's synergy with Jedi Knight Revan once Jedi Master Luke is present.

### DIFF
--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -5101,7 +5101,8 @@
             }
           ]
         }
-      ]
+      ],
+      "requiresAllZetas": false
     },
     {
       "id": "KUIIL",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -1587,7 +1587,6 @@
       "id": "CC2224",
       "baseTier": 14,
       "requiresAllZetas": false,
-      "requiredZetas": [],
       "synergySets": [
         {
           "synergyEnhancement": 4,
@@ -1609,10 +1608,14 @@
           "categoryDefinitions": [
             {
               "include": [
-                "Clone Trooper"
+                "Clone Trooper",
+                "Light Side"
               ],
               "numberMatchesRequired": 3
             }
+          ],
+          "skipIfPresentCharacters": [
+            "GENERALSKYWALKER"
           ]
         }
       ]
@@ -1796,10 +1799,14 @@
           "categoryDefinitions": [
             {
               "include": [
-                "Clone Trooper"
+                "Clone Trooper",
+                "Light Side"
               ],
               "numberMatchesRequired": 3
             }
+          ],
+          "skipIfPresentCharacters": [
+            "GENERALSKYWALKER"
           ]
         }
       ]

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -2151,7 +2151,12 @@
     {
       "baseTier": 4,
       "id": "DARTHBANE",
-      "omicronEnhancement": 1
+      "omicronEnhancement": 1,
+      "requiredZetas": [
+        "uniqueskill_DARTHBANE01",
+        "basicskill_DARTHBANE"
+      ],
+      "requiresAllZetas": false
     },
     {
       "id": "DARTHMALAK",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -2151,12 +2151,7 @@
     {
       "baseTier": 4,
       "id": "DARTHBANE",
-      "omicronEnhancement": 1,
-      "requiredZetas": [
-        "uniqueskill_DARTHBANE01",
-        "basicskill_DARTHBANE"
-      ],
-      "requiresAllZetas": false
+      "omicronEnhancement": 1
     },
     {
       "id": "DARTHMALAK",

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -617,6 +617,9 @@
           "synergyEnhancement": 3,
           "characters": [
             "JEDIKNIGHTREVAN"
+          ],
+          "skipIfPresentCharacters": [
+            "GRANDMASTERLUKE"
           ]
         }
       ]


### PR DESCRIPTION
## Description
Jedi Master Luke takes Jedi Knight Revan for his team most of the time.
Satele Shan will likely change the meta but will require a new synergy
including her.

### Characters Affected
- Bastila Shan
