### PR TITLE
Move Pester tests to dedicated PowerShell workflow

### DIFF
--- a/.github/workflows/validate-powershell.yml
+++ b/.github/workflows/validate-powershell.yml
@@ -1,0 +1,45 @@
+name: Validate PowerShell Scripts
+
+on:
+    pull_request:
+        branches: [main]
+        paths:
+            - "Tools/**/*.ps1"
+            - "Tools/**/*.psm1"
+            - "Tests/**/*.ps1"
+            - "Tests/**/*.psm1"
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    pester-tests:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Install Pester
+              shell: pwsh
+              run: |
+                  Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+                  Import-Module Pester -MinimumVersion 5.0.0
+                  Write-Host "Pester $((Get-Module Pester).Version) installed"
+
+            - name: Run Pester tests
+              shell: pwsh
+              run: |
+                  $config = & ./Tests/.pester.ps1
+                  $config.Run.Exit = $true
+                  $config.TestResult.OutputPath = './TestResults/testResults.xml'
+                  Invoke-Pester -Configuration $config
+
+            - name: Upload Pester test results
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: pester-test-results
+                  path: TestResults/testResults.xml
+                  if-no-files-found: ignore

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -181,29 +181,6 @@ jobs:
                   Write-Host "✓ PowerShell validation passed"
                   Write-Host "::endgroup::"
 
-            - name: Run Pester tests
-              shell: pwsh
-              run: |
-                  Write-Host "::group::Running Pester tests"
-
-                  Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
-                  Import-Module Pester -MinimumVersion 5.0.0
-
-                  $config = & ./Tests/.pester.ps1
-                  $config.Run.Exit = $true
-                  $config.TestResult.OutputPath = './TestResults/testResults.xml'
-                  Invoke-Pester -Configuration $config
-
-                  Write-Host "::endgroup::"
-
-            - name: Upload Pester test results
-              if: always()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: pester-test-results
-                  path: TestResults/testResults.xml
-                  if-no-files-found: ignore
-
             - name: Check JSON formatting (2-space indentation)
               run: |
                   echo "::group::Checking JSON formatting"


### PR DESCRIPTION
## Changes

- **New** `validate-powershell.yml` — runs Pester tests when `.ps1`/`.psm1` files change
- **Updated** `validate-pr.yml` — removed Pester steps (stays focused on JSON data validation)

## Why

Pester tests were only running when `characterBaseData.json` changed, meaning PowerShell script changes went untested in CI. Now they trigger on any script/test file change.

## Trigger paths
- `Tools/**/*.ps1`  `Tools/**/*.psm1`  `Tests/**/*.ps1`  `Tests/**/*.psm1`