### PR TITLE
Consolidate validation into single source of truth

### DIFF
--- a/Tests/StartVisualEditor.Tests.ps1
+++ b/Tests/StartVisualEditor.Tests.ps1
@@ -267,6 +267,32 @@ Describe 'VisualEditorFunctions' {
             ($errors | Where-Object { $_ -match 'numberMatchesRequired' }).Count | Should -BeGreaterThan 0
         }
 
+        It 'Should return error when synergy set exceeds 4-slot limit' {
+            $data = @(
+                [PSCustomObject]@{
+                    id = 'ALPHA'
+                    baseTier = 5
+                    synergySets = @(
+                        [PSCustomObject]@{
+                            synergyEnhancement = 3
+                            characters = @('BRAVO', 'CHARLIE', 'DELTA')
+                            categoryDefinitions = @(
+                                [PSCustomObject]@{
+                                    include = @('Sith')
+                                    numberMatchesRequired = 2
+                                }
+                            )
+                        }
+                    )
+                },
+                [PSCustomObject]@{ id = 'BRAVO'; baseTier = 10 },
+                [PSCustomObject]@{ id = 'CHARLIE'; baseTier = 10 },
+                [PSCustomObject]@{ id = 'DELTA'; baseTier = 10 }
+            )
+            $errors = @(Test-CharacterData -CharacterArray $data)
+            ($errors | Where-Object { $_ -match 'slot limit' }).Count | Should -BeGreaterThan 0
+        }
+
         It 'Should accumulate multiple errors' {
             $data = @(
                 [PSCustomObject]@{ id = 'BRAVO'; baseTier = 0 },
@@ -274,6 +300,21 @@ Describe 'VisualEditorFunctions' {
             )
             $errors = Test-CharacterData -CharacterArray $data
             $errors.Count | Should -BeGreaterThan 1
+        }
+
+        It 'Should serialize single error as JSON array (not string)' {
+            # Reproduces the "errors.forEach is not a function" bug where
+            # PowerShell unwraps a single-element array to a plain string,
+            # causing ConvertTo-Json to emit a string instead of an array.
+            $data = @(
+                [PSCustomObject]@{ id = 'ALPHA'; baseTier = 25 }
+            )
+            $errors = Test-CharacterData -CharacterArray $data
+            $result = @{ valid = $false; errors = @($errors) }
+            $json = $result | ConvertTo-Json
+            # Verify the JSON contains "errors": [...] not "errors": "..."
+            $json | Should -Match '"errors":\s*\[' -Because 'errors must be a JSON array even with a single error'
+            $json | Should -Not -Match '"errors":\s*"' -Because 'errors must not be serialized as a plain string'
         }
 
         It 'Should pass valid data with synergy sets' {

--- a/Tests/StartVisualEditor.Tests.ps1
+++ b/Tests/StartVisualEditor.Tests.ps1
@@ -343,24 +343,28 @@ Describe 'VisualEditorFunctions' {
     }
 
     Context 'Get-StaticFilePath' {
+        BeforeAll {
+            $editorBase = Join-Path $TestDrive 'editor'
+        }
+
         It 'Should return index.html for root path' {
-            $result = Get-StaticFilePath -UrlPath '/' -EditorPath 'C:\editor'
-            $result | Should -Be 'C:\editor\index.html'
+            $result = Get-StaticFilePath -UrlPath '/' -EditorPath $editorBase
+            $result | Should -Be (Join-Path $editorBase 'index.html')
         }
 
         It 'Should return index.html for empty path' {
-            $result = Get-StaticFilePath -UrlPath '' -EditorPath 'C:\editor'
-            $result | Should -Be 'C:\editor\index.html'
+            $result = Get-StaticFilePath -UrlPath '' -EditorPath $editorBase
+            $result | Should -Be (Join-Path $editorBase 'index.html')
         }
 
         It 'Should resolve normal file path' {
-            $result = Get-StaticFilePath -UrlPath '/styles.css' -EditorPath 'C:\editor'
-            $result | Should -Be 'C:\editor\styles.css'
+            $result = Get-StaticFilePath -UrlPath '/styles.css' -EditorPath $editorBase
+            $result | Should -Be (Join-Path $editorBase 'styles.css')
         }
 
         It 'Should resolve nested path' {
-            $result = Get-StaticFilePath -UrlPath '/sub/file.js' -EditorPath 'C:\editor'
-            $result | Should -Be 'C:\editor\sub\file.js'
+            $result = Get-StaticFilePath -UrlPath '/sub/file.js' -EditorPath $editorBase
+            $result | Should -Be (Join-Path $editorBase 'sub' 'file.js')
         }
     }
 }

--- a/Tests/ValidateCharacterData.Tests.ps1
+++ b/Tests/ValidateCharacterData.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'ValidateCharacterData' {
 
             $result = Invoke-ValidationScript -DataPath $testFile
             $result.ExitCode | Should -Be 1
-            $result.Output | Should -Match 'sorted alphabetically|sorting'
+            $result.Output | Should -Match 'sorted alphabetically|sorting|alphabetical order'
         }
 
         It 'Should pass when characters are sorted alphabetically' {

--- a/Tools/StartVisualEditor.ps1
+++ b/Tools/StartVisualEditor.ps1
@@ -146,7 +146,7 @@ try {
                 $validationErrors = Test-CharacterData -CharacterArray $characterArray
 
                 if ($validationErrors.Count -gt 0) {
-                    $errorMsg = @{ error = "Validation failed"; details = $validationErrors } | ConvertTo-Json
+                    $errorMsg = @{ error = "Validation failed"; details = @($validationErrors) } | ConvertTo-Json
                     $buffer = [System.Text.Encoding]::UTF8.GetBytes($errorMsg)
                     $response.ContentType = "application/json; charset=utf-8"
                     $response.ContentLength64 = $buffer.Length
@@ -198,7 +198,7 @@ try {
                     @{ valid = $true; errors = @() }
                 }
                 else {
-                    @{ valid = $false; errors = $validationErrors }
+                    @{ valid = $false; errors = @($validationErrors) }
                 }
 
                 $resultJson = $result | ConvertTo-Json

--- a/Tools/ValidateCharacterData.ps1
+++ b/Tools/ValidateCharacterData.ps1
@@ -10,6 +10,8 @@ param (
 
 $ErrorActionPreference = 'Stop'
 
+Import-Module (Join-Path $PSScriptRoot "VisualEditorFunctions.psm1") -Force
+
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host "Character Base Data Validation Script" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
@@ -28,11 +30,11 @@ Write-Host "Validating: $CharacterBaseDataPath" -ForegroundColor White
 Write-Host ""
 
 # ====================
-# 1. JSON Parsing Test
+# 1. JSON Parsing
 # ====================
-Write-Host "[1/8] Testing JSON parsing..." -ForegroundColor Yellow
+Write-Host "[1/5] Testing JSON parsing..." -ForegroundColor Yellow
 try {
-    $characterBaseData = Get-Content $CharacterBaseDataPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $jsonData = Get-Content $CharacterBaseDataPath -Raw -Encoding UTF8 | ConvertFrom-Json
     Write-Host "  ✓ Valid JSON structure" -ForegroundColor Green
 }
 catch {
@@ -42,303 +44,42 @@ catch {
 }
 
 # ====================
-# 2. Structure Validation
+# 2. Data Validation (via shared module)
 # ====================
-Write-Host "[2/8] Validating data structure..." -ForegroundColor Yellow
-if (-not $characterBaseData.characterBaseData) {
-    $validationErrors += "Missing root 'characterBaseData' property"
-    Write-Host "  ✗ FAILED: Missing root 'characterBaseData' property" -ForegroundColor Red
-}
-elseif ($characterBaseData.characterBaseData -isnot [System.Array]) {
-    $validationErrors += "'characterBaseData' must be an array"
-    Write-Host "  ✗ FAILED: 'characterBaseData' must be an array" -ForegroundColor Red
+Write-Host "[2/5] Running data validation..." -ForegroundColor Yellow
+
+$characterArrayRaw = ConvertTo-CharacterArray -JsonData $jsonData
+
+if ($null -eq $characterArrayRaw) {
+    Write-Host "  ✗ FAILED: Invalid data structure (missing or invalid 'characterBaseData' array)" -ForegroundColor Red
+    $validationErrors += "Invalid data structure"
 }
 else {
-    Write-Host "  ✓ Valid root structure" -ForegroundColor Green
-}
+    $characterArray = @($characterArrayRaw)
+    Write-Host "  ℹ Total characters: $($characterArray.Count)" -ForegroundColor Cyan
 
-$characterBaseDataItems = $characterBaseData.characterBaseData
-$totalCharacters = $characterBaseDataItems.Count
-Write-Host "  ℹ Total characters: $totalCharacters" -ForegroundColor Cyan
+    $dataErrors = @(Test-CharacterData -CharacterArray $characterArray)
 
-# ====================
-# 3. Duplicate ID Check
-# ====================
-Write-Host "[3/8] Checking for duplicate character IDs..." -ForegroundColor Yellow
-$characterIds = @{}
-$duplicates = @()
-
-foreach ($character in $characterBaseDataItems) {
-    if (-not $character.id) {
-        $validationErrors += "Character found without 'id' property"
-        continue
-    }
-    
-    if ($characterIds.ContainsKey($character.id)) {
-        $duplicates += $character.id
-        $validationErrors += "Duplicate character ID: $($character.id)"
+    if ($dataErrors.Count -eq 0) {
+        Write-Host "  ✓ All data validation checks passed" -ForegroundColor Green
     }
     else {
-        $characterIds[$character.id] = $true
-    }
-}
-
-if ($duplicates.Count -eq 0) {
-    Write-Host "  ✓ No duplicate IDs found" -ForegroundColor Green
-}
-else {
-    Write-Host "  ✗ FAILED: Found $($duplicates.Count) duplicate ID(s)" -ForegroundColor Red
-    foreach ($dup in $duplicates) {
-        Write-Host "    - $dup" -ForegroundColor Red
-    }
-}
-
-# ====================
-# 4. Alphabetical Sorting Check
-# ====================
-Write-Host "[4/8] Validating alphabetical sorting..." -ForegroundColor Yellow
-$sortedIds = $characterBaseDataItems.id | Sort-Object
-$actualIds = $characterBaseDataItems.id
-$sortingErrors = @()
-
-for ($i = 0; $i -lt $actualIds.Count; $i++) {
-    if ($actualIds[$i] -ne $sortedIds[$i]) {
-        $sortingErrors += "Position $($i + 1): Expected '$($sortedIds[$i])', found '$($actualIds[$i])'"
-    }
-}
-
-if ($sortingErrors.Count -eq 0) {
-    Write-Host "  ✓ Characters are sorted alphabetically" -ForegroundColor Green
-}
-else {
-    Write-Host "  ✗ FAILED: Characters are not sorted alphabetically" -ForegroundColor Red
-    $validationErrors += "Characters must be sorted alphabetically by ID"
-    if ($sortingErrors.Count -le 5) {
-        foreach ($error in $sortingErrors) {
-            Write-Host "    $error" -ForegroundColor Red
+        Write-Host "  ✗ FAILED: Found $($dataErrors.Count) validation error(s)" -ForegroundColor Red
+        $validationErrors += $dataErrors
+        $displayCount = [Math]::Min($dataErrors.Count, 10)
+        for ($i = 0; $i -lt $displayCount; $i++) {
+            Write-Host "    $($dataErrors[$i])" -ForegroundColor Red
         }
-    }
-    else {
-        Write-Host "    Showing first 5 of $($sortingErrors.Count) sorting errors:" -ForegroundColor Red
-        for ($i = 0; $i -lt 5; $i++) {
-            Write-Host "    $($sortingErrors[$i])" -ForegroundColor Red
+        if ($dataErrors.Count -gt 10) {
+            Write-Host "    ... and $($dataErrors.Count - 10) more error(s)" -ForegroundColor Red
         }
     }
 }
 
 # ====================
-# 5. Field Validation
+# 3. JSON Formatting Check
 # ====================
-Write-Host "[5/8] Validating required fields and data types..." -ForegroundColor Yellow
-$fieldErrors = @()
-$characterIndex = 0
-
-foreach ($character in $characterBaseDataItems) {
-    $characterIndex++
-    $charId = if ($character.id) { $character.id } else { "<missing-id at index $characterIndex>" }
-    
-    # Validate 'id' field
-    if (-not $character.id) {
-        $fieldErrors += "[$charId] Missing required field: 'id'"
-    }
-    elseif ($character.id -notmatch '^[A-Z0-9_]+$') {
-        $fieldErrors += "[$charId] Invalid ID format: must contain only uppercase letters, numbers, and underscores"
-    }
-    
-    # Validate 'baseTier' field
-    if ($null -eq $character.baseTier) {
-        $fieldErrors += "[$charId] Missing required field: 'baseTier'"
-    }
-    elseif ($character.baseTier -isnot [System.ValueType] -or $character.baseTier -isnot [System.IConvertible]) {
-        $fieldErrors += "[$charId] 'baseTier' must be an integer"
-    }
-    elseif ($character.baseTier -lt 1 -or $character.baseTier -gt 19) {
-        $fieldErrors += "[$charId] 'baseTier' must be between 1 and 19 (found: $($character.baseTier))"
-    }
-    
-    # Validate 'synergySets' if present
-    if ($character.synergySets) {
-        if ($character.synergySets -isnot [System.Array]) {
-            $fieldErrors += "[$charId] 'synergySets' must be an array"
-        }
-        else {
-            $synergyIndex = 0
-            foreach ($synergySet in $character.synergySets) {
-                $synergyIndex++
-                
-                # Check that at least one enhancement type is present
-                if ($null -eq $synergySet.synergyEnhancement -and $null -eq $synergySet.synergyEnhancementOmicron) {
-                    $fieldErrors += "[$charId] Synergy set #$synergyIndex must have at least one of 'synergyEnhancement' or 'synergyEnhancementOmicron'"
-                }
-                
-                # Validate synergyEnhancement if present
-                if ($null -ne $synergySet.synergyEnhancement) {
-                    if ($synergySet.synergyEnhancement -isnot [System.ValueType] -or $synergySet.synergyEnhancement -isnot [System.IConvertible]) {
-                        $fieldErrors += "[$charId] Synergy set #$synergyIndex 'synergyEnhancement' must be an integer"
-                    }
-                    elseif ($synergySet.synergyEnhancement -lt 0 -or $synergySet.synergyEnhancement -gt 10) {
-                        $fieldErrors += "[$charId] Synergy set #$synergyIndex 'synergyEnhancement' must be between 0 and 10 (found: $($synergySet.synergyEnhancement))"
-                    }
-                }
-                
-                # Validate synergyEnhancementOmicron if present
-                if ($null -ne $synergySet.synergyEnhancementOmicron) {
-                    if ($synergySet.synergyEnhancementOmicron -isnot [System.ValueType] -or $synergySet.synergyEnhancementOmicron -isnot [System.IConvertible]) {
-                        $fieldErrors += "[$charId] Synergy set #$synergyIndex 'synergyEnhancementOmicron' must be an integer"
-                    }
-                    elseif ($synergySet.synergyEnhancementOmicron -lt 0 -or $synergySet.synergyEnhancementOmicron -gt 10) {
-                        $fieldErrors += "[$charId] Synergy set #$synergyIndex 'synergyEnhancementOmicron' must be between 0 and 10 (found: $($synergySet.synergyEnhancementOmicron))"
-                    }
-                }
-                
-                # Validate characters array if present
-                if ($synergySet.characters) {
-                    if ($synergySet.characters -isnot [System.Array]) {
-                        $fieldErrors += "[$charId] Synergy set #$synergyIndex 'characters' must be an array"
-                    }
-                    elseif ($synergySet.characters.Count -lt 1 -or $synergySet.characters.Count -gt 4) {
-                        $fieldErrors += "[$charId] Synergy set #$synergyIndex 'characters' array must contain between 1 and 4 elements (found: $($synergySet.characters.Count))"
-                    }
-                }
-                
-                # Validate categoryDefinitions if present
-                if ($synergySet.categoryDefinitions) {
-                    if ($synergySet.categoryDefinitions -isnot [System.Array]) {
-                        $fieldErrors += "[$charId] Synergy set #$synergyIndex 'categoryDefinitions' must be an array"
-                    }
-                    else {
-                        $catIndex = 0
-                        foreach ($catDef in $synergySet.categoryDefinitions) {
-                            $catIndex++
-                            
-                            if (-not $catDef.include) {
-                                $fieldErrors += "[$charId] Synergy set #$synergyIndex, category #$catIndex missing required field: 'include'"
-                            }
-                            elseif ($catDef.include -isnot [System.Array]) {
-                                $fieldErrors += "[$charId] Synergy set #$synergyIndex, category #$catIndex 'include' must be an array"
-                            }
-                            
-                            if ($null -eq $catDef.numberMatchesRequired) {
-                                $fieldErrors += "[$charId] Synergy set #$synergyIndex, category #$catIndex missing required field: 'numberMatchesRequired'"
-                            }
-                            elseif ($catDef.numberMatchesRequired -isnot [System.ValueType] -or $catDef.numberMatchesRequired -isnot [System.IConvertible]) {
-                                $fieldErrors += "[$charId] Synergy set #$synergyIndex, category #$catIndex 'numberMatchesRequired' must be an integer"
-                            }
-                            elseif ($catDef.numberMatchesRequired -lt 1 -or $catDef.numberMatchesRequired -gt 4) {
-                                $fieldErrors += "[$charId] Synergy set #$synergyIndex, category #$catIndex 'numberMatchesRequired' must be between 1 and 4"
-                            }
-                        }
-                    }
-                }
-
-                # Validate total characters referenced in synergy set does not exceed 4
-                $totalCharactersInSet = 0
-                if ($synergySet.characters) {
-                    $totalCharactersInSet += $synergySet.characters.Count
-                }
-
-                if ($synergySet.categoryDefinitions) {
-                    foreach ($catDef in $synergySet.categoryDefinitions) {
-                        if ($catDef.include) {
-                            $totalCharactersInSet += $catDef.numberMatchesRequired
-                        }
-                    }
-                }
-
-                if ($totalCharactersInSet -lt 1 -or $totalCharactersInSet -gt 4) {
-                    $fieldErrors += "[$charId] Synergy set #$synergyIndex must reference between 1 and 4 total characters (found: $totalCharactersInSet)"
-                }
-            }
-        }
-    }
-}
-
-if ($fieldErrors.Count -eq 0) {
-    Write-Host "  ✓ All required fields valid" -ForegroundColor Green
-}
-else {
-    Write-Host "  ✗ FAILED: Found $($fieldErrors.Count) field validation error(s)" -ForegroundColor Red
-    $validationErrors += $fieldErrors
-    if ($fieldErrors.Count -le 10) {
-        foreach ($error in $fieldErrors) {
-            Write-Host "    $error" -ForegroundColor Red
-        }
-    }
-    else {
-        Write-Host "    Showing first 10 of $($fieldErrors.Count) field errors:" -ForegroundColor Red
-        for ($i = 0; $i -lt 10; $i++) {
-            Write-Host "    $($fieldErrors[$i])" -ForegroundColor Red
-        }
-    }
-}
-
-# ====================
-# 6. Character Cross-Reference Validation
-# ====================
-Write-Host "[6/9] Validating character cross-references..." -ForegroundColor Yellow
-
-# Build set of all valid character IDs
-$validCharacterIds = @{}
-foreach ($character in $characterBaseDataItems) {
-    if ($character.id) {
-        $validCharacterIds[$character.id] = $true
-    }
-}
-
-$crossRefErrors = @()
-
-# Check all character references in synergy sets
-foreach ($character in $characterBaseDataItems) {
-    $charId = if ($character.id) { $character.id } else { "<missing-id>" }
-    
-    if ($character.synergySets) {
-        $synergyIndex = 0
-        foreach ($synergySet in $character.synergySets) {
-            $synergyIndex++
-            
-            if ($synergySet.characters) {
-                foreach ($referencedCharId in $synergySet.characters) {
-                    if (-not $validCharacterIds.ContainsKey($referencedCharId)) {
-                        $crossRefErrors += "[$charId] Synergy set #$synergyIndex references non-existent character: '$referencedCharId'"
-                    }
-                }
-            }
-            
-            if ($synergySet.skipIfPresentCharacters) {
-                foreach ($excludedCharId in $synergySet.skipIfPresentCharacters) {
-                    if (-not $validCharacterIds.ContainsKey($excludedCharId)) {
-                        $crossRefErrors += "[$charId] Synergy set #$synergyIndex skipIfPresentCharacters references non-existent character: '$excludedCharId'"
-                    }
-                }
-            }
-        }
-    }
-}
-
-if ($crossRefErrors.Count -eq 0) {
-    Write-Host "  ✓ All character references are valid" -ForegroundColor Green
-}
-else {
-    Write-Host "  ✗ FAILED: Found $($crossRefErrors.Count) invalid character reference(s)" -ForegroundColor Red
-    $validationErrors += $crossRefErrors
-    if ($crossRefErrors.Count -le 10) {
-        foreach ($error in $crossRefErrors) {
-            Write-Host "    $error" -ForegroundColor Red
-        }
-    }
-    else {
-        Write-Host "    Showing first 10 of $($crossRefErrors.Count) reference errors:" -ForegroundColor Red
-        for ($i = 0; $i -lt 10; $i++) {
-            Write-Host "    $($crossRefErrors[$i])" -ForegroundColor Red
-        }
-    }
-}
-
-# ====================
-# 7. JSON Formatting Check
-# ====================
-Write-Host "[7/9] Validating JSON formatting..." -ForegroundColor Yellow
-$rawContent = Get-Content $CharacterBaseDataPath -Raw
+Write-Host "[3/5] Validating JSON formatting..." -ForegroundColor Yellow
 $formattingIssues = @()
 
 # Check for proper indentation (2 spaces)
@@ -355,11 +96,9 @@ foreach ($line in $lines) {
     }
 }
 
-# Check encoding (should be UTF-8)
-$encoding = [System.Text.Encoding]::Default
+# Check encoding (should be UTF-8 without BOM)
 try {
     $bytes = [System.IO.File]::ReadAllBytes($CharacterBaseDataPath)
-    # Check for UTF-8 BOM
     if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
         $validationWarnings += "File has UTF-8 BOM (Byte Order Mark) - consider using UTF-8 without BOM"
     }
@@ -380,61 +119,62 @@ else {
 }
 
 # ====================
-# 8. Statistics Summary
+# 4. Statistics Summary
 # ====================
-Write-Host "[8/9] Generating statistics..." -ForegroundColor Yellow
-$tierDistribution = @{}
-for ($i = 1; $i -le 19; $i++) { $tierDistribution[$i] = 0 }
+Write-Host "[4/5] Generating statistics..." -ForegroundColor Yellow
 
-$charactersWithSynergies = 0
-$totalSynergySets = 0
-$maxSynergyEnhancement = 0
+if ($null -ne $characterArray) {
+    $tierDistribution = @{}
+    for ($i = 1; $i -le 19; $i++) { $tierDistribution[$i] = 0 }
 
-foreach ($character in $characterBaseDataItems) {
-    if ($character.baseTier -ge 1 -and $character.baseTier -le 19) {
-        $tierDistribution[$character.baseTier]++
-    }
-    
-    if ($character.synergySets) {
-        $charactersWithSynergies++
-        $totalSynergySets += $character.synergySets.Count
-        
-        foreach ($synergySet in $character.synergySets) {
-            if ($synergySet.synergyEnhancement -gt $maxSynergyEnhancement) {
-                $maxSynergyEnhancement = $synergySet.synergyEnhancement
+    $charactersWithSynergies = 0
+    $totalSynergySets = 0
+    $maxSynergyEnhancement = 0
+
+    foreach ($character in $characterArray) {
+        if ($character.baseTier -ge 1 -and $character.baseTier -le 19) {
+            $tierDistribution[$character.baseTier]++
+        }
+
+        if ($character.synergySets) {
+            $charactersWithSynergies++
+            $totalSynergySets += $character.synergySets.Count
+
+            foreach ($synergySet in $character.synergySets) {
+                if ($synergySet.synergyEnhancement -gt $maxSynergyEnhancement) {
+                    $maxSynergyEnhancement = $synergySet.synergyEnhancement
+                }
             }
+        }
+    }
+
+    Write-Host "  ℹ Characters with synergies: $charactersWithSynergies / $($characterArray.Count)" -ForegroundColor Cyan
+    Write-Host "  ℹ Total synergy sets: $totalSynergySets" -ForegroundColor Cyan
+    Write-Host "  ℹ Max synergy enhancement: $maxSynergyEnhancement" -ForegroundColor Cyan
+    Write-Host "  ℹ Tier distribution:" -ForegroundColor Cyan
+    $sortedTiers = $tierDistribution.Keys | Sort-Object
+    foreach ($tier in $sortedTiers) {
+        if ($tierDistribution[$tier] -gt 0) {
+            $bar = "#" * [Math]::Min($tierDistribution[$tier], 50)
+            Write-Host "      Tier $($tier.ToString().PadLeft(2)): $($tierDistribution[$tier].ToString().PadLeft(3)) $bar" -ForegroundColor Cyan
         }
     }
 }
 
-Write-Host "  ℹ Characters with synergies: $charactersWithSynergies / $totalCharacters" -ForegroundColor Cyan
-Write-Host "  ℹ Total synergy sets: $totalSynergySets" -ForegroundColor Cyan
-Write-Host "  ℹ Max synergy enhancement: $maxSynergyEnhancement" -ForegroundColor Cyan
-Write-Host "  ℹ Tier distribution:" -ForegroundColor Cyan
-$sortedTiers = $tierDistribution.Keys | Sort-Object
-foreach ($tier in $sortedTiers) {
-    if ($tierDistribution[$tier] -gt 0) {
-        $bar = "#" * [Math]::Min($tierDistribution[$tier], 50)
-        Write-Host "      Tier $($tier.ToString().PadLeft(2)): $($tierDistribution[$tier].ToString().PadLeft(3)) $bar" -ForegroundColor Cyan
-    }
-}
-
 # ====================
-# 9. JSON Schema Validation (External)
+# 5. JSON Schema Validation (External)
 # ====================
-Write-Host "[9/9] JSON Schema validation..." -ForegroundColor Yellow
+Write-Host "[5/5] JSON Schema validation..." -ForegroundColor Yellow
 
 if ($UseExternalValidator) {
-    # Try to use ajv-cli if available
     $ajvAvailable = $null -ne (Get-Command "ajv" -ErrorAction SilentlyContinue)
-    
+
     if ($ajvAvailable -and (Test-Path $SchemaPath)) {
         Write-Host "  ℹ Running ajv schema validator..." -ForegroundColor Cyan
-        
-        # Resolve to absolute paths for cross-platform compatibility
+
         $absoluteSchemaPath = Resolve-Path $SchemaPath
         $absoluteDataPath = Resolve-Path $CharacterBaseDataPath
-        
+
         try {
             $ajvResult = & ajv validate -s $absoluteSchemaPath -d $absoluteDataPath 2>&1
             if ($LASTEXITCODE -eq 0) {

--- a/Tools/VisualEditorFunctions.psm1
+++ b/Tools/VisualEditorFunctions.psm1
@@ -114,7 +114,8 @@ function ConvertTo-CharacterArray {
     }
 
     if ($null -ne $JsonData.characterBaseData) {
-        return $JsonData.characterBaseData
+        # Force to array in case PowerShell unwrapped a single-element array
+        return @($JsonData.characterBaseData)
     }
     elseif ($JsonData -is [Array]) {
         return $JsonData
@@ -177,6 +178,11 @@ function Test-CharacterData {
             continue
         }
 
+        # Check character ID format (uppercase letters, numbers, underscores only)
+        if ($charId -notmatch '^[A-Z0-9_]+$') {
+            $validationErrors += "Character '$charId' has invalid ID format (must be uppercase letters, numbers, and underscores only)"
+        }
+
         # Check for duplicates
         if ($seenIds.ContainsKey($charId)) {
             $validationErrors += "Duplicate character ID: $charId"
@@ -236,6 +242,15 @@ function Test-CharacterData {
                     }
                 }
 
+                # Check skipIfPresentCharacters cross-references
+                if ($null -ne $synergySet.skipIfPresentCharacters -and $synergySet.skipIfPresentCharacters -is [Array]) {
+                    foreach ($refCharId in $synergySet.skipIfPresentCharacters) {
+                        if (!$characterIds.ContainsKey($refCharId)) {
+                            $validationErrors += "Character '$charId' synergy set #$setIndex skipIfPresentCharacters references non-existent character: $refCharId"
+                        }
+                    }
+                }
+
                 # Check numberMatchesRequired range
                 if ($null -ne $synergySet.categoryDefinitions -and $synergySet.categoryDefinitions -is [Array]) {
                     $catIndex = 0
@@ -247,6 +262,24 @@ function Test-CharacterData {
                             }
                         }
                     }
+                }
+
+                # Check synergy slot limit: characters + sum(numberMatchesRequired) <= 4
+                $charSlots = 0
+                if ($null -ne $synergySet.characters -and $synergySet.characters -is [Array]) {
+                    $charSlots = $synergySet.characters.Count
+                }
+                $categorySlots = 0
+                if ($null -ne $synergySet.categoryDefinitions -and $synergySet.categoryDefinitions -is [Array]) {
+                    foreach ($catDef in $synergySet.categoryDefinitions) {
+                        if ($null -ne $catDef.numberMatchesRequired) {
+                            $categorySlots += $catDef.numberMatchesRequired
+                        }
+                    }
+                }
+                $totalSlots = $charSlots + $categorySlots
+                if ($totalSlots -gt 4) {
+                    $validationErrors += "Character '$charId' synergy set #$setIndex exceeds 4-slot limit: $charSlots character(s) + $categorySlots category match(es) = $totalSlots"
                 }
             }
         }


### PR DESCRIPTION
## Summary

Eliminates duplicate validation logic by refactoring `ValidateCharacterData.ps1` to use the module's `Test-CharacterData` function as the single source of truth.

## Changes

### Consolidation
- **`Tools/ValidateCharacterData.ps1`** — Rewritten from ~500 lines to ~210 lines. Now imports `VisualEditorFunctions.psm1` and delegates all data validation to `Test-CharacterData` instead of reimplementing it. Steps reduced from 9 to 5.
- Eliminates the `Cannot validate argument on parameter 'MaximumHistoryCount'. The 0 argument is less than the minimum allowed range of 1. Supply an argument that is greater than or equal to 1 and then try the command again.` automatic variable conflict bug

### New Validations (in `Test-CharacterData`)
- **Synergy slot limit** — `characters.length + sum(numberMatchesRequired) <= 4` per synergy set
- **skipIfPresentCharacters cross-references** — validates referenced character IDs exist
- **Character ID format** — enforces `^[A-Z0-9_]+$` pattern

### Bug Fixes
- **`Tools/StartVisualEditor.ps1`** — Fixed single-element array unwrapping on `/api/validate` and `/api/save` endpoints (was causing `errors.forEach is not a function` in editor)
- **`Tools/VisualEditorFunctions.psm1`** — `ConvertTo-CharacterArray` now wraps with `@()` to prevent single-element unwrapping

### Tests
- Added synergy slot limit test
- Added JSON array serialization test (prevents regression of the `forEach` bug)
- Updated sorting error message regex
- **All 60 Pester tests pass**

## Validation
- [x] `ValidateCharacterData.ps1` correctly catches MAZKANATA slot limit violation
- [x] Visual editor displays validation errors properly (no `forEach` crash)
- [x] All 60 Pester tests pass (38 visual editor + 22 validation script)