### PR TITLE
Update Pirate synergies and MAZKANATA tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ __pycache__/
 # Backup files
 *.bak
 *.backup
+TestResults/testResults.xml

--- a/Data/characterBaseData.json
+++ b/Data/characterBaseData.json
@@ -4715,8 +4715,15 @@
           "characters": [
             "MAZKANATA",
             "KIX",
-            "QUIGGOLD",
-            "SM33"
+            "QUIGGOLD"
+          ],
+          "categoryDefinitions": [
+            {
+              "include": [
+                "Pirate"
+              ],
+              "numberMatchesRequired": 1
+            }
           ]
         }
       ]
@@ -5900,7 +5907,7 @@
     },
     {
       "id": "MAZKANATA",
-      "baseTier": 15,
+      "baseTier": 13,
       "synergySets": [
         {
           "synergyEnhancement": 5,
@@ -5908,8 +5915,15 @@
           "characters": [
             "ITHANO",
             "KIX",
-            "QUIGGOLD",
-            "SM33"
+            "QUIGGOLD"
+          ],
+          "categoryDefinitions": [
+            {
+              "include": [
+                "Pirate"
+              ],
+              "numberMatchesRequired": 1
+            }
           ]
         }
       ],


### PR DESCRIPTION
## Changes

### Character Updates
- **ITHANO**: Replace SM33 in synergy characters with Pirate category definition (numberMatchesRequired: 1)
- **MAZKANATA**: Adjust baseTier from 15 to 13, replace SM33 in synergy characters with Pirate category definition

### Other
- Added TestResults/testResults.xml to .gitignore

## Validation
- [x] ValidateCharacterData.ps1 passes
- [x] All 61 Pester tests pass