### PR TITLE
Fix Azure DevOps sync destination path

### DIFF
--- a/.github/workflows/sync-to-azdo.yml
+++ b/.github/workflows/sync-to-azdo.yml
@@ -23,7 +23,7 @@ jobs:
             AZDO_ORG: ${{ secrets.AZDO_ORG }}
             AZDO_PROJECT: ${{ secrets.AZDO_PROJECT }}
             AZDO_REPO: ${{ secrets.AZDO_REPO }}
-            AZDO_DEST_PATH: swgoh-stackrank-webapp/swgoh-stackrank-webapp/Data/characterBaseData.json
+            AZDO_DEST_PATH: src/swgoh-stackrank-webapp/Data/characterBaseData.json
 
         steps:
             - name: Checkout GitHub repo


### PR DESCRIPTION
## Summary
- update the Azure DevOps sync destination to `src/swgoh-stackrank-webapp/Data/characterBaseData.json`
- align the workflow with the destination repository's new directory structure

## Failure addressed
- https://github.com/NducTiOnomBi/swgoh-stackrank/actions/runs/32672221006/job/97274656514

## Validation
- parsed the updated workflow as valid YAML
- confirmed the diff contains only the destination path correction